### PR TITLE
fix: update PluginDescriptor args

### DIFF
--- a/src/main/java/com/diabolickal/pickpocketinfo/PickpocketInfoPlugin.java
+++ b/src/main/java/com/diabolickal/pickpocketinfo/PickpocketInfoPlugin.java
@@ -22,9 +22,7 @@ import java.util.regex.Pattern;
 @PluginDescriptor(
         name = "Pickpocket Info",
         description = "Shows helpful pickpocketing info.",
-        tags = {"thieving", "pickpocket"},
-        loadWhenOutdated = true,
-        enabledByDefault = false
+        tags = {"thieving", "pickpocket"}
 )
 
 @Slf4j


### PR DESCRIPTION
Fixes #7

```
> Task :compileJava FAILED
/tmp/pluginhub-package11082602222547477078/pickpocket-info/repo/src/main/java/com/diabolickal/pickpocketinfo/PickpocketInfoPlugin.java:26: error: cannot find symbol
        loadWhenOutdated = true,
        ^
  symbol:   method loadWhenOutdated()
  location: @interface PluginDescriptor
1 error
```